### PR TITLE
Fixed a number of compiler warnings caused by missing virtual function override specifiers

### DIFF
--- a/jcf_advanced_leak_detector/jcf_advanced_leak_detector.h
+++ b/jcf_advanced_leak_detector/jcf_advanced_leak_detector.h
@@ -1,15 +1,52 @@
+/*
+  ==============================================================================
+
+    jcf_advanced_leak_detector.h
+    Created: 21 Jul 2014 12:08:08pm
+    Author:  Jim Credland
+
+  ==============================================================================
+*/
+
+/*
+
+ BEGIN_JUCE_MODULE_DECLARATION
+
+  ID:               jcf_advanced_leak_detector
+  vendor:           juce
+  version:          4.2.1
+  name:             JCF LEAK DETECTOR
+  description:      Advanced leak detector for JUCE
+  website:          http://www.github.com/jcredland/
+  license:          MIT
+
+  dependencies:     juce_core
+  OSXFrameworks:
+  iOSFrameworks:
+
+ END_JUCE_MODULE_DECLARATION
+ */
+
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+namespace jcf {
+
+using namespace juce;
 
 /** Stick an instance of this in a class that JUCE is reporting memory leaks for
  and you'll get a nice report with a stack trace which should lead you to a
  happy place quite quickly.
- 
- It might slow down your program a bit, so don't forget to take it out once your 
+
+ It might slow down your program a bit, so don't forget to take it out once your
  problems are all fixed.  In fact. I've wrapped it in a #ifdef JUCE_DEBUG so you
  can't forget.  Forgetting would be bad.
- 
- If the JUCE_LEAK_DETECTOR assert fires first, just push the continue button 
+
+ If the JUCE_LEAK_DETECTOR assert fires first, just push the continue button
  on your debugger and this should report straight afterwards.
  */
+
 #ifdef JUCE_DEBUG
 class AdvancedLeakDetector {
 public:
@@ -48,3 +85,5 @@ private:
 
 };
 #endif
+
+}

--- a/jcf_debug/jcf_debug.h
+++ b/jcf_debug/jcf_debug.h
@@ -9,7 +9,7 @@
 */
 
 /*
- 
+
  BEGIN_JUCE_MODULE_DECLARATION
 
   ID:               jcf_debug
@@ -21,8 +21,8 @@
   license:          MIT
 
   dependencies:     juce_core juce_graphics juce_gui_basics juce_gui_extra
-  OSXFrameworks:    
-  iOSFrameworks:    
+  OSXFrameworks:
+  iOSFrameworks:
 
  END_JUCE_MODULE_DECLARATION
  */
@@ -37,14 +37,13 @@
 #include <juce_gui_extra/juce_gui_extra.h>
 
 namespace jcf {
-    
+
 using namespace juce;
 
 #include "source/buffer_debugger.h"
 #include "source/value_tree_debugger.h"
 #include "source/component_debugger.h"
 #include "source/font_and_colour_designer.h"
-#include "source/advanced_leak_detector.h"
 
 }
 

--- a/jcf_debug/source/buffer_debugger.cpp
+++ b/jcf_debug/source/buffer_debugger.cpp
@@ -388,13 +388,13 @@ public:
             list.setRowHeight (13.0f);
         }
 
-        int getNumRows()
+        int getNumRows() override
         {
             return BufferDebuggerStore::getInstance()->size();
         }
 
         void paintListBoxItem (int rowNumber, Graphics& g,
-                               int width, int height, bool rowIsSelected)
+                               int width, int height, bool rowIsSelected) override
         {
             String s = BufferDebuggerStore::getInstance()->get (rowNumber)->getName();
 
@@ -410,12 +410,12 @@ public:
             owner.bufferListUpdated();
         }
 
-        void paint (Graphics& g)
+        void paint (Graphics& g) override
         {
             g.fillAll (Colours::lightgrey);
         }
 
-        void resized()
+        void resized() override
         {
             list.setBounds (getLocalBounds());
         }
@@ -447,7 +447,7 @@ public:
 
     ~BufferDebuggerMain();
 
-    void timerCallback()
+    void timerCallback() override
     {
         repaint();
     }

--- a/jcf_debug/source/component_debugger.cpp
+++ b/jcf_debug/source/component_debugger.cpp
@@ -30,7 +30,7 @@ public:
         h.addListener (this);
     }
 
-    void resized()
+    void resized() override
     {
         panel.setBounds (getLocalBounds());
     }

--- a/jcf_debug/source/font_and_colour_designer.cpp
+++ b/jcf_debug/source/font_and_colour_designer.cpp
@@ -16,12 +16,12 @@ public:
         setSize (300, 400);
         addChangeListener (this);
     }
-    void setSwatchColour (int index, const Colour& newColour) const override
+    void setSwatchColour (int index, const Colour& newColour) const
     {
         targetColour = newColour;
         comp.repaint();
     }
-    void changeListenerCallback (ChangeBroadcaster*)
+    void changeListenerCallback (ChangeBroadcaster*) override
     {
         targetColour = getCurrentColour();
         comp.repaint();
@@ -52,7 +52,7 @@ public:
         addAndMakeVisible (list);
     }
 
-    void resized()
+    void resized() override
     {
         list.setBounds (getLocalBounds());
     }
@@ -68,7 +68,7 @@ public:
         updateFont();
     }
 
-    void selectedRowsChanged (int lastRowSelected)
+    void selectedRowsChanged (int lastRowSelected) override
     {
         number = lastRowSelected;
         updateFont();
@@ -130,7 +130,7 @@ public:
         tree.addListener (this);
     }
 
-    void resized()
+    void resized() override
     {
         tree        .setBounds (getLocalBounds().withTrimmedBottom (20));
         openButton  .setBounds (getLocalBounds().withTop (getHeight() - 20));
@@ -144,7 +144,7 @@ public:
         comp.repaint();
     }
 
-    void buttonClicked (Button*)
+    void buttonClicked (Button*) override
     {
         bool success = fileChooser.browseForDirectory();
 


### PR DESCRIPTION
Title says it all. Was getting a bunch of warnings in Xcode 9 because of the missing overrides, and an error from overriding a non-virtual function (in that case I removed `override` so it overloads instead).