### PR TITLE
Fix nullptr dereference crash

### DIFF
--- a/jcf_debug/source/buffer_debugger.cpp
+++ b/jcf_debug/source/buffer_debugger.cpp
@@ -476,9 +476,12 @@ private:
 };
 
 
-BufferDebugger::BufferDebugger() : DocumentWindow ("Debug Buffer Viewer",
-            Colours::lightgrey,
-            DocumentWindow::allButtons)
+BufferDebugger::BufferDebugger()
+    :
+    DocumentWindow ("Debug Buffer Viewer",
+        Colours::lightgrey,
+        DocumentWindow::allButtons),
+    mainComponent (new BufferDebuggerMain)
 {
     mainComponent->setSize (500, 250);
     setContentNonOwned (mainComponent, true);


### PR DESCRIPTION
BufferDebugger was crashing in the constructor because the mainComponent member was never being initialized. This has been fixed by adding mainComponent to the initializer list.