### PR TITLE
Update lldb formatters for var, Array, ValueTree, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See https://msdn.microsoft.com/en-us/library/jj620914.aspx
 An equivalent LLDB file is provided.  Installation instructions are in the
 comments at the top of the file.  See juce_lldb_xcode.py.
 
-If you'd like to add new types, see [Sudara's getting started guide](https://melatonin.dev/blog/how-to-create-lldb-type-summaries-and-synthetic-children-for-your-custom-types/).
+If you'd like to add new types, see [Sudara's guide to creating lldb type summaries and children](https://melatonin.dev/blog/how-to-create-lldb-type-summaries-and-synthetic-children-for-your-custom-types/).
 
 ## JCF_DEBUG: JUCE Debugging Module
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ See https://msdn.microsoft.com/en-us/library/jj620914.aspx
 An equivalent LLDB file is provided.  Installation instructions are in the
 comments at the top of the file.  See juce_lldb_xcode.py.
 
+If you'd like to add new types, see [Sudara's getting started guide](https://melatonin.dev/blog/how-to-create-lldb-type-summaries-and-synthetic-children-for-your-custom-types/).
+
 ## JCF_DEBUG: JUCE Debugging Module
 
 There are five development debugging utilities in the juce module jcf_debug.

--- a/juce_lldb_xcode.py
+++ b/juce_lldb_xcode.py
@@ -124,6 +124,8 @@ def var_summary(valueObject, dictionary):
         value = "double=" + varValue.GetChildMemberWithName("doubleValue").GetValue()
     elif varType.GetChildMemberWithName("isBool").GetValue() == "true":
         value = "bool=" + varValue.GetChildMemberWithName("boolValue").GetValue()
+    elif varType.GetChildMemberWithName("isVoid").GetValue() == "true":
+        value = "void"
     return value
 
 def ComponentSummary(valueObject, dictionary):
@@ -248,14 +250,12 @@ class ArrayChildrenProvider:
 
         # ReferenceCountedArrays store pointers, *not* the objects themselves
         if (self.valueObject.GetTypeName().startswith("juce::ReferenceCounted")):
-            print("pointer motherfucker")
             self.data_type = self.valueObject.GetType().GetTemplateArgumentType(0).GetPointerType()
-            self.data_size = self.data_type.GetByteSize()
         else:
             # type of first template argument. For example juce::Array<int> would be int
             self.data_type = self.valueObject.GetType().GetTemplateArgumentType(0)
-            self.data_size = self.data_type.GetByteSize()
 
+        self.data_size = self.data_type.GetByteSize()
         if self.first_element.IsValid():
             self.count = self.valueObject.GetChildMemberWithName('values').GetChildMemberWithName('numUsed').GetValueAsUnsigned()
         else:

--- a/juce_lldb_xcode.py
+++ b/juce_lldb_xcode.py
@@ -1,12 +1,12 @@
 import lldb
 #
 # ABOUT
-# 
-# This file allows LLDB to decode some common JUCE structures, 
+#
+# This file allows LLDB to decode some common JUCE structures,
 # in particular Arrays, Strings, var objects and ValueTrees.
 #
-# The facilities aren't quite as nice as those in VisualStudio 
-# so if you do find you need to disable any functionality you 
+# The facilities aren't quite as nice as those in VisualStudio
+# so if you do find you need to disable any functionality you
 # can do so in the __lldb_init_module function by commentting
 # out the appropriate debugger.* line.
 #
@@ -14,12 +14,12 @@ import lldb
 #
 # USAGE
 #
-# Put this line in your ~/.lldbinit file: 
+# Put this line in your ~/.lldbinit file:
 #
 #  command script import [path]
 #
 # Where [path] is the full path to this file. For example:
-# 
+#
 #  command script import /Users/me/juce-toys/juce_lldb_xcode.py
 #
 #
@@ -37,9 +37,9 @@ import lldb
 # services including:
 # - JUCE software development and support
 # - information security consultancy
-# 
+#
 # Contact jim@credland.net
-# 
+#
 ###################################
 #
 # Much Python/LLDB magic...
@@ -48,229 +48,218 @@ def __lldb_init_module(debugger, dict):
     print("-- juce decoding modules loaded.  www.credland.net")
     print(" - refer to the help for the 'type' command")
 
-    # ValueTree<*>
-    debugger.HandleCommand('type synthetic add "juce::ValueTree" --python-class juce_lldb_xcode.ValueTreeChildrenProvider -w juce')
-
     # Array<*>
+    # --inline-children shows the values of children in summaries, -O only shows values, not keys
+    debugger.HandleCommand('type summary add -x "^juce::(ReferenceCounted)?Array<.*>" --inline-children -O -w juce')
     debugger.HandleCommand('type synthetic add -x "^juce::(ReferenceCounted)?Array<.*>" --python-class juce_lldb_xcode.ArrayChildrenProvider -w juce')
 
     # Component
     debugger.HandleCommand('type summary add juce::Component -F juce_lldb_xcode.ComponentSummary -w juce')
 
     # String
-    debugger.HandleCommand('type summary add juce::String -F juce_lldb_xcode.string_summary -w juce')
+    debugger.HandleCommand('type summary add juce::String --summary-string "${var.text.data}" -w juce')
 
     # var
     debugger.HandleCommand('type summary add juce::var -F juce_lldb_xcode.var_summary -w juce')
 
     # Identifier
-    debugger.HandleCommand('type summary add juce::Identifier -F juce_lldb_xcode.identifier_summary -w juce')
+    debugger.HandleCommand('type summary add juce::Identifier --summary-string "${var.name}" -w juce')
+
+    # NamedValueSet::NamedValue
+    debugger.HandleCommand('type summary add juce::NamedValueSet::NamedValue --summary-string "${var.name}: ${var.value}" -w juce')
+
+    # NamedValueSet (for example, ValueTree properties)
+    debugger.HandleCommand('type summary add juce::NamedValueSet --inline-children -w juce')
+    debugger.HandleCommand('type synthetic add juce::NamedValueSet --python-class juce_lldb_xcode.NamedValueSetProvider -w juce')
+
+    # ValueTree and ValueTree::SharedObject
+    debugger.HandleCommand('type summary add juce::ValueTree -F juce_lldb_xcode.value_tree_summary -w juce')
+    debugger.HandleCommand('type synthetic add juce::ValueTree --python-class juce_lldb_xcode.ValueTreeChildrenProvider -w juce')
+    debugger.HandleCommand('type summary add juce::ValueTree::SharedObject -F juce_lldb_xcode.value_tree_summary -w juce')
+    debugger.HandleCommand('type synthetic add juce::ValueTree::SharedObject --python-class juce_lldb_xcode.ValueTreeChildrenProvider -w juce')
 
     # ScopedPointer
     debugger.HandleCommand('type summary add -x "^juce::ScopedPointer<.*>" --summary-string "ScopedPointer<>=${*var.object}" -w juce')
 
     # Rectangle<*>
     debugger.HandleCommand('type summary add -x "^juce::Rectangle<.*>" --summary-string "${var.pos.x} ${var.pos.y} ${var.w} ${var.h}" -w juce')
+
     debugger.HandleCommand('type category enable juce')
 
+def named_value_set_summary(valueObject, dictionary):
+    # Reach through the Array and the ArrayBase
+    number_of_values = valueObject.GetChildMemberWithName('values').GetChildMemberWithName('values').GetChildMemberWithName('numUsed').GetSummary()
+    return number_of_values + " properties"
 
-def string_summary(valueObject, dictionary):
-    #print dir(lldb.frame)
-    s = valueObject.GetChildMemberWithName('text').GetChildMemberWithName('data').GetSummary()
-    return s
+def value_tree_summary(valueObject, dictionary):
+    valueTreeType = valueObject.GetChildMemberWithName('type').GetSummary() or "none"
+    # we need to look at the NonSynthetic version of the NamedValueSet to get at numUsed
+    numProperties = valueObject.GetChildMemberWithName('properties').GetNonSyntheticValue().GetChildMemberWithName('values').GetChildMemberWithName('values').GetChildMemberWithName('numUsed').GetValue() or "0"
+    numChildren = str(valueObject.GetChildMemberWithName('children').GetNonSyntheticValue().GetChildMemberWithName('values').GetChildMemberWithName('numUsed').GetValueAsUnsigned()) or "0"
+    return "type: " + valueTreeType + ", " + numProperties + (" property" if numProperties == "1" else " properties") + ", " + numChildren + (" child" if numChildren == "1" else " children")
 
-def identifier_summary(valueObject, dictionary):
-    s = valueObject.GetChildMemberWithName('name').GetChildMemberWithName('text').GetChildMemberWithName('data').GetSummary()
-    if s is None:
-        return "((uninitalized))"
-    else:
-        return s
-    
 def rect_summary(valueObject, dictionary):
     w = valueObject.GetChildMemberWithName('w').GetValue()
     h = valueObject.GetChildMemberWithName('h').GetValue()
     pos = valueObject.GetChildMemberWithName('pos')
     x = pos.GetChildMemberWithName('x').GetValue()
     y = pos.GetChildMemberWithName('y').GetValue()
-
     s = "x=" + str(x) + " y=" + str(y)
-
     s = s + " w=" + str(w) + " h=" + str(h)
-
     return s
-
-# Types of VAR
-#    class VariantType;            friend class VariantType;
-#
-#    class VariantType_Void;       friend class VariantType_Void;
-#    class VariantType_Undefined;  friend class VariantType_Undefined;
-#    class VariantType_Int;        friend class VariantType_Int;
-#
-#    class VariantType_Int64;      friend class VariantType_Int64;
-#    class VariantType_Double;     friend class VariantType_Double;
-#    class VariantType_Bool;       friend class VariantType_Bool;
-#
-#    class VariantType_String;     friend class VariantType_String;
-#    class VariantType_Object;     friend class VariantType_Object;
-#    class VariantType_Array;      friend class VariantType_Array;
-#
-#    class VariantType_Binary;     friend class VariantType_Binary;
-#    class VariantType_Method;     friend class VariantType_Method;
 
 def var_summary(valueObject, dictionary):
-    varType = valueObject.GetChildMemberWithName('type').GetType()
+    varType = valueObject.GetChildMemberWithName('type')
     varValue = valueObject.GetChildMemberWithName('value')
-    s = "t"
-    if varType.GetName() == "juce::var::VariantType_String *":
-        stringValue = varValue.GetChildMemberWithName('stringValue')
-        stringPointerType = valueObject.GetFrame().GetModule().FindFirstType('juce::String').GetPointerType()
-        print(stringPointerType)
-        stringPointer = stringValue.Cast(stringPointerType)
-        print(stringPointer)
-        s = 'string=' + stringPointer.Dereference().GetSummary() + stringPointer.GetValue()
-        # now we have to convert the .value to a pointer ... 
-    if varType.GetName() == "juce::var::VariantType_Int *":
-        s = 'int=' + varValue.GetSummary()
-    return s
+    value = varType.GetType()
+    if varType.GetChildMemberWithName("isString").GetValue() == "true":
+        # the data inside var is char[8] and needs to be cast to a juce::String
+        char8Data = varValue.GetChildMemberWithName('stringValue')
+        juceStringType = valueObject.GetFrame().GetModule().FindFirstType('juce::String')
+        castedStringData = char8Data.Cast(juceStringType).GetSummary()
+        value = 'string=' + castedStringData
+    elif varType.GetChildMemberWithName("isInt").GetValue() == "true":
+        value = "int=" + varValue.GetChildMemberWithName("intValue").GetValue()
+    elif varType.GetChildMemberWithName("isDouble").GetValue() == "true":
+        value = "double=" + varValue.GetChildMemberWithName("doubleValue").GetValue()
+    elif varType.GetChildMemberWithName("isBool").GetValue() == "true":
+        value = "bool=" + varValue.GetChildMemberWithName("boolValue").GetValue()
+    return value
 
 def ComponentSummary(valueObject, dictionary):
     # Component 'name' parent=None visible=True location={ 0, 0, 20, 20 } opaque=False
-    print(int(valueObject.GetChildMemberWithName('parentComponent').GetValue(), 16))
+    # print(int(valueObject.GetChildMemberWithName('parentComponent').GetValue(), 16))
     hasParent = int(valueObject.GetChildMemberWithName('parentComponent').GetValue(), 16) == 0
     isVisible = valueObject.GetChildMemberWithName('flags').GetChildMemberWithName('visibleFlag').GetValue()
-    print(type(isVisible))
     name = string_summary(valueObject.GetChildMemberWithName('componentName'), dictionary)
-
     s = name + " hasParent=" + str(hasParent) + " isVisible=" + str(isVisible)
-
     return s
 
 
+# This provider isn't DRY. It dupes some behavior from juce::Array.
+# I couldn't figure out how to rely on the array provider from this one.
+class NamedValueSetProvider:
+    def __init__(self, valueObject, internalDict):
+        self.valueObject = valueObject
+        self.values = self.valueObject.GetChildMemberWithName('values')
+        self.update()
 
+    def num_children(self):
+        return self.size
+
+    def get_child_index(self, name):
+        return int(name.lstrip('[').rstrip(']'))
+
+    def get_child_at_index(self, index):
+        # couldn't figure out how to delegate to the "values" member, which is a juce::Array
+        # So, instead we'll create children like we do on juce::Array
+        offset = index * self.data_size
+        return self.first_element.CreateChildAtOffset('[' + str(index) + ']', offset, self.data_type)
+
+    def update(self):
+        # Dig into the array to get at the num of elements
+        self.size = self.values.GetChildMemberWithName('values').GetChildMemberWithName('numUsed').GetValueAsUnsigned()
+
+        self.first_element = self.values.GetChildMemberWithName('values').GetChildMemberWithName('elements').GetChildMemberWithName('data')
+
+        # this is NamedValueSet::NamedValue
+        self.data_type = self.values.GetType().GetTemplateArgumentType(0)
+        self.data_size = self.data_type.GetByteSize()
+
+    def has_children(self):
+        return self.size > 0
 
 class ValueTreeChildrenProvider:
     def __init__(self, valueObject, internalDict):
-        # this call should initialize the Python object using valobj as the
-        # variable to provide synthetic children for. 
-        #
-        # JCF_ Most of the actual work is done in update()
-        print("VTCP with " + valueObject.GetName())
-        self.v = valueObject
-        self.count = 0
+        # parents and children are stored as SharedObjects
+        if (valueObject.GetTypeName() == "juce::ValueTree::SharedObject"):
+            self.valueObject = valueObject
+            # print ("ok, shared object is:")
+            # print(self.valueObject)
+        # parent is stored as a pointer to a SharedObject
+        elif (valueObject.GetTypeName() == "juce::ValueTree::SharedObject *"):
+            self.valueObject = valueObject.Dereference()
+        else:
+            # For juce::ValueTree proper, dig out the referenced object
+            self.valueObject = valueObject.GetChildMemberWithName('object').GetChildMemberWithName('referencedObject')
+
         self.update()
-        return
 
-    def num_children(self): 
-        # Return (a) properties and (b) children
-        return 4 
+    def num_children(self):
+        return 4
 
-    def get_child_index(self, name): 
-        # this call should return the index of the synthetic child whose name is
-        # given as argument 
-        print("get_child_index: " + name)
-        try:
-            return int(name.lstrip('[').rstrip(']'))
-        except:
-            return -1
+    def get_child_index(self, name):
+        if name == "type":
+          return 0
 
-    def get_child_at_index(self, index): 
+        if name == "parent":
+          return 1
+
+        if name == "properties":
+          return 2
+
+        if name == "children":
+          return 3
+
+    def get_child_at_index(self, index):
         if index == 0:
-            return self.ro.GetChildMemberWithName('properties').GetChildMemberWithName('values')
+            return self.type
 
         if index == 1:
-            return self.ro.GetChildMemberWithName('children')
-        
+            return self.parent
+
         if index == 2:
-            return self.ro.GetChildMemberWithName('parent')
+            return self.properties
 
         if index == 3:
-            return self.ro.GetChildMemberWithName('type')
+            return self.children
 
         return None
 
-    def update(self): 
-        # this call should be used to update the internal state of this Python
-        # object whenever the state of the variables in LLDB changes.[1]
-        self.ro = self.v.GetChildMemberWithName('object').GetChildMemberWithName('referencedObject')
-        return 
+    # update is called before every other method
+    def update(self):
+        self.type = self.valueObject.GetChildMemberWithName('type')
+        self.parent = self.valueObject.GetChildMemberWithName('parent')
+        self.properties = self.valueObject.GetChildMemberWithName('properties')
+        # relies on ArrayChildrenProvider being defined for ReferenceCountedArray
+        self.children = self.valueObject.GetChildMemberWithName('children')
 
-    def has_children(self): 
-        # this call should return True if this object might have children, and False if
-        # this object can be guaranteed not to have children.[2]
+    def has_children(self):
         return True
-
 
 class ArrayChildrenProvider:
     def __init__(self, valueObject, internalDict):
-        # this call should initialize the Python object using valobj as the
-        # variable to provide synthetic children for. 
-        #
-        # JCF_ Most of the actual work is done in update()
-        print("ACP with " + valueObject.GetName())
-        self.v = valueObject
+        self.valueObject = valueObject
         self.count = 0
         self.update()
-        return
 
-    def num_children(self): 
-        # this call should return the number of children that you want your
-        # object to have 
-        #
-        # JC - no matter what we do here it seems to call get_child_at_index
-        # target.max-children times
-        if (self.count > 100):
-            print("WARNING count = " + self.count)
-        return int(self.count)
+    def num_children(self):
+        return self.count
 
-    def get_child_index(self, name): 
-        # this call should return the index of the synthetic child whose name is
-        # given as argument 
-        print("get_child_index: " + name)
-        try:
-            return int(name.lstrip('[').rstrip(']'))
-        except:
-            return -1
+    def get_child_index(self, name):
+        return int(name.lstrip('[').rstrip(']'))
 
-    def get_child_at_index(self, index): 
-        # this call should return a new LLDB SBValue object representing 
-        # the child at the index given as argument 
-        if index < 0:
-            return None
-        
-        if index >= self.count:
-            return None
+    def get_child_at_index(self, index):
+        offset = index * self.data_size
+        return self.first_element.CreateChildAtOffset('[' + str(index) + ']', offset, self.data_type)
 
-        try:
-            offset = index * self.data_size
-            return self.first_element.CreateChildAtOffset('[' + str(index) + ']', offset, self.data_type)
-        except:
-            print("Array<> error")
-            return None
+    def update(self):
+        self.first_element = self.valueObject.GetChildMemberWithName('values').GetChildMemberWithName('elements').GetChildMemberWithName('data')
 
-    def update(self): 
-        # this call should be used to update the internal state of this Python
-        # object whenever the state of the variables in LLDB changes.[1]
-        data = self.v.GetChildMemberWithName('data')
-        self.first_element = data.GetChildMemberWithName('elements').GetChildMemberWithName('data')
-        self.data_type = self.first_element.GetType().GetPointeeType()
-        self.data_size = self.data_type.GetByteSize()
+        # ReferenceCountedArrays store pointers, *not* the objects themselves
+        if (self.valueObject.GetTypeName().startswith("juce::ReferenceCounted")):
+            print("pointer motherfucker")
+            self.data_type = self.valueObject.GetType().GetTemplateArgumentType(0).GetPointerType()
+            self.data_size = self.data_type.GetByteSize()
+        else:
+            # type of first template argument. For example juce::Array<int> would be int
+            self.data_type = self.valueObject.GetType().GetTemplateArgumentType(0)
+            self.data_size = self.data_type.GetByteSize()
 
         if self.first_element.IsValid():
-            # GetValue() returns a string(!) so we have to cast to an integer here.
-            try:
-                self.count = int(self.v.GetChildMemberWithName('numUsed').GetValue())
-            except TypeError:
-                print("ACP invalid numUsed.  Set count to 0")
-                self.count = 0
+            self.count = self.valueObject.GetChildMemberWithName('values').GetChildMemberWithName('numUsed').GetValueAsUnsigned()
         else:
             self.count = 0
 
-        print("ACP set self.count to " + str(self.count))
-
-        return 
-
-    def has_children(self): 
-        # this call should return True if this object might have children, and False if
-        # this object can be guaranteed not to have children.[2]
+    def has_children(self):
         return self.count > 0
-


### PR DESCRIPTION
This PR updates the lldb formatting for JUCE types. Some of the internals have changed in JUCE 5 and JUCE 6 over the years, so existing formatters for `juce::Array` and `juce::ValueTree` haven't been very happy. This fixes that up!

This is what the value tree summary looks like:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/472/159179690-3a05242b-c8d3-4c6a-8643-558557646bef.png">

And the children:

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/472/159179711-5e45fda7-711c-4111-8cfc-27dfbe144f00.png">

I've also taken the liberty of inlining children for Array types:

<img width="786" alt="image" src="https://user-images.githubusercontent.com/472/159179721-e19d8d32-bca9-4266-b069-bce4a11d9f5f.png">

I also added a link to [a blog article I wrote on lldb formatters](https://melatonin.dev/blog/how-to-create-lldb-type-summaries-and-synthetic-children-for-your-custom-types/). If that's distasteful, feel free to just cherry pick the formatters!
